### PR TITLE
Use gh to download packages

### DIFF
--- a/home/private_dot_local/bin/executable_install-marksman.tmpl
+++ b/home/private_dot_local/bin/executable_install-marksman.tmpl
@@ -1,16 +1,13 @@
 #! /bin/bash
 
-VERSION="2022-09-13"
-BASE_URL="https://github.com/artempyanykh/marksman/releases/download"
-
-BIN_DIR=$HOME/.local/bin
+bin_dir=$HOME/.local/bin
 
 {{ if (eq .chezmoi.os "darwin") -}}
-RELEASE_URL=$BASE_URL/$VERSION/marksman-macos
+glob_pattern="*macos"
 {{ else if (eq .chezmoi.os "linux") -}}
-RELEASE_URL=$BASE_URL/$VERSION/marksman-linux
+glob_pattern="*linux"
 {{ end -}}
 
-curl -fsSL $RELEASE_URL > marksman
-mv marksman $BIN_DIR/marksman
-chmod +x $BIN_DIR/marksman
+gh release download --repo artempyanykh/marksman --pattern $glob_pattern
+mv marksman* $bin_dir/marksman
+chmod +x $bin_dir/marksman

--- a/home/private_dot_local/bin/executable_install-rust-analyzer.tmpl
+++ b/home/private_dot_local/bin/executable_install-rust-analyzer.tmpl
@@ -1,17 +1,14 @@
 #! /bin/bash
 
-VERSION="2022-09-26"
-BASE_URL="https://github.com/rust-lang/rust-analyzer/releases/download"
-
-BIN_DIR=$HOME/.local/bin
+bin_dir=$HOME/.local/bin
 
 {{ if (eq .chezmoi.os "darwin") -}}
-RELEASE_URL=$BASE_URL/$VERSION/rust-analyzer-aarch64-apple-darwin.gz
+glob_pattern="*aarch64*darwin*"
 {{ else if (eq .chezmoi.os "linux") -}}
-RELEASE_URL=$BASE_URL/$VERSION/rust-analyzer-aarch64-unknown-linux-gnu.gz
+glob_pattern="*aarch64*linux*"
 {{ end -}}
 
-curl -fsSL $RELEASE_URL > rust-analyzer.gz
-gunzip rust-analyzer.gz
-mv rust-analyzer $BIN_DIR/rust-analyzer
-chmod +x $BIN_DIR/rust-analyzer
+gh release download --repo rust-lang/rust-analyzer --pattern $glob_pattern
+gunzip $glob_pattern
+mv $glob_pattern $bin_dir/rust-analyzer
+chmod +x $bin_dir/rust-analyzer


### PR DESCRIPTION
Addresses issue https://github.com/gdtroszak/dotfiles/issues/3

- Update marksman install to use gh.
- Use gh to install rust-analyzer.